### PR TITLE
#19 use a Manifest for agents creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dependencies:
 check: dependencies
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install --update
-	gometalinter -j2 --config "$(CURDIR)/gometalinter.json" ./...
+	gometalinter -j2 --deadline 60s --config "$(CURDIR)/gometalinter.json" ./...
 
 coverage:
 	go get golang.org/x/tools/cmd/cover

--- a/agentiface/agent.go
+++ b/agentiface/agent.go
@@ -29,10 +29,11 @@ type Agent interface {
 	Identity
 
 	Logger
-	Manifest
 	Messaging
 	Cli
 	Config
 	SchemaRegistry
 	TypeRegistry
+
+	Manifest() Manifest
 }

--- a/agentimpl/agent.go
+++ b/agentimpl/agent.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cespare/wait"
+	"github.com/crucibuild/sdk-agent-go/agentiface"
 	"github.com/crucibuild/sdk-agent-go/agentimpl/cmd"
 	"github.com/crucibuild/sdk-agent-go/util"
 )
@@ -37,24 +38,23 @@ type Agent struct {
 	*SchemaRegistry
 	*TypeRegistry
 	*AMQP
-	*Manifest
 	*Logger
 
-	id string
+	id       string
+	manifest agentiface.Manifest
 }
 
 // NewAgent creates a new Agent instance from a spec.
-func NewAgent(agentSpec map[string]interface{}) (agent *Agent, err error) {
+func NewAgent(manifest agentiface.Manifest) (agent *Agent, err error) {
 	agent = &Agent{
-		id: fmt.Sprintf("%s@%s#%d", agentSpec["name"].(string), util.Host(), time.Now().UnixNano()),
+		id: fmt.Sprintf("%s@%s#%d", manifest.Name(), util.Host(), time.Now().UnixNano()),
 	}
 
-	agent.Manifest = NewManifest(agentSpec)
+	agent.manifest = manifest
 	if agent.Logger, err = NewLogger(agent); err != nil {
 		return
 	}
 	agent.Cli = NewCli(agent)
-
 	agent.Config = NewConfig(agent)
 	agent.SchemaRegistry = NewSchemaRegistry(agent)
 	agent.TypeRegistry = NewTypeRegistry(agent)
@@ -72,4 +72,9 @@ func NewAgent(agentSpec map[string]interface{}) (agent *Agent, err error) {
 // ID returns the agent id.
 func (a *Agent) ID() string {
 	return a.id
+}
+
+// Manifest returns the manifest of the agent.
+func (a *Agent) Manifest() agentiface.Manifest {
+	return a.manifest
 }

--- a/agentimpl/cli.go
+++ b/agentimpl/cli.go
@@ -32,8 +32,8 @@ func NewCli(a agentiface.Agent) *Cli {
 	cli := &Cli{
 		agent: a,
 		rootCmd: &cobra.Command{
-			Use:   a.Name(),
-			Short: a.Description(),
+			Use:   a.Manifest().Name(),
+			Short: a.Manifest().Description(),
 			Long:  "",
 			PersistentPreRun: func(cmd *cobra.Command, args []string) {
 				a.Info(a.ID())
@@ -43,7 +43,7 @@ func NewCli(a agentiface.Agent) *Cli {
 
 				if file == "" {
 					// default configuration file
-					file = fmt.Sprintf("%s/%s", fmt.Sprintf(agentiface.ConfigPathLocal, a.Name()), agentiface.ConfigName)
+					file = fmt.Sprintf("%s/%s", fmt.Sprintf(agentiface.ConfigPathLocal, a.Manifest().Name()), agentiface.ConfigName)
 				}
 
 				err := a.LoadConfigFrom(file)

--- a/agentimpl/cmd/config.go
+++ b/agentimpl/cmd/config.go
@@ -26,7 +26,7 @@ import (
 // RegisterCmdConfig registers command line "config" command which enables the user to interact with the agent config.
 func RegisterCmdConfig(a agentiface.Agent) {
 	// Manage flags:
-	a.RootCommand().PersistentFlags().String("config", "", fmt.Sprintf("config file (default is $HOME/.%s/%s)", a.Name(), agentiface.ConfigName))
+	a.RootCommand().PersistentFlags().String("config", "", fmt.Sprintf("config file (default is $HOME/.%s/%s)", a.Manifest().Name(), agentiface.ConfigName))
 
 	// Register commands
 	a.RegisterCommand(cmdConfigInit(a))

--- a/agentimpl/cmd/manifest.go
+++ b/agentimpl/cmd/manifest.go
@@ -38,7 +38,7 @@ func cmdManifestVersion(a agentiface.Agent) *cobra.Command {
 		Short: "Provide the version of the agent",
 		Long:  `Provide the version of the agent.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(a.Version())
+			fmt.Println(a.Manifest().Version())
 		},
 	}
 
@@ -51,7 +51,7 @@ func cmdManifestName(a agentiface.Agent) *cobra.Command {
 		Short: "Provide the name of the agent",
 		Long:  `Provide the name of the agent.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(a.Name())
+			fmt.Println(a.Manifest().Name())
 		},
 	}
 
@@ -69,9 +69,9 @@ func cmdManifestShow(a agentiface.Agent) *cobra.Command {
 			var raw []byte
 			var err error
 			if prettyFormat {
-				raw, err = json.MarshalIndent(a.Spec(), "", "  ")
+				raw, err = json.MarshalIndent(a.Manifest().Spec(), "", "  ")
 			} else {
-				raw, err = json.Marshal(a.Spec())
+				raw, err = json.Marshal(a.Manifest().Spec())
 			}
 
 			if err != nil {

--- a/agentimpl/log.go
+++ b/agentimpl/log.go
@@ -31,7 +31,7 @@ func NewLogger(a agentiface.Agent) (*Logger, error) {
 	l.Targets = append(l.Targets, t1)
 	l.CallStackDepth = 0
 
-	l.Category = a.Name()
+	l.Category = a.Manifest().Name()
 
 	err := l.Open()
 

--- a/agentimpl/message.go
+++ b/agentimpl/message.go
@@ -387,7 +387,7 @@ func (a *AMQP) declareQueues() (err error) {
 	}
 
 	a.cmdQueues[1], err = a.channel.QueueDeclare(
-		fmt.Sprintf("%s@%s", a.agent.Name(), util.Host()),
+		fmt.Sprintf("%s@%s", a.agent.Manifest().Name(), util.Host()),
 		false, // durable
 		false, // delete when unused
 		false, // exclusive
@@ -414,7 +414,7 @@ func (a *AMQP) declareQueues() (err error) {
 	}
 
 	a.cmdQueues[2], err = a.channel.QueueDeclare(
-		a.agent.Name(),
+		a.agent.Manifest().Name(),
 		false, // durable
 		false, // delete when unused
 		false, // exclusive

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -12,7 +12,6 @@
         "interfacer",
         "megacheck",
         "misspell",
-        "safesql",
         "structcheck",
         "unparam",
         "varcheck"
@@ -20,6 +19,7 @@
     "Unused": [
         "lll",
         "dupl",
-        "goimports"
+        "goimports",
+        "safesql"
     ]
 }


### PR DESCRIPTION
Here is a minimal improvement which addresses #19. There's a room for others improvements, but currently, it does the job.

As the fix breaks the interface for the agents that use this sdk, we should not delay too much the PR.