### PR TITLE
#22 Add JSON Schema support

### DIFF
--- a/agentimpl/schemaAvro.go
+++ b/agentimpl/schemaAvro.go
@@ -16,7 +16,6 @@ package agentimpl
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/crucibuild/sdk-agent-go/agentiface"
 	"github.com/crucibuild/sdk-agent-go/util"
 	"github.com/elodina/go-avro"
@@ -27,11 +26,10 @@ const MimeTypeAvroSchema = "application/js+avro"
 
 // AvroSchema represents an AVRO schema with all its metadata.
 type AvroSchema struct {
-	id       string
-	title    string
-	mimetype string
-	raw      string
-	schema   avro.Schema
+	id     string
+	title  string
+	raw    string
+	schema avro.Schema
 }
 
 // ID returns the AvroSchema ID.
@@ -45,8 +43,8 @@ func (s *AvroSchema) Title() string {
 }
 
 // MimeType returns the AvroSchema mime type.
-func (s *AvroSchema) MimeType() string {
-	return s.mimetype
+func (*AvroSchema) MimeType() string {
+	return MimeTypeAvroSchema
 }
 
 // Raw returns the raw AvroSchema.
@@ -89,7 +87,7 @@ func (s *AvroSchema) Code(o interface{}) ([]byte, error) {
 // the registry is given as argument in order to resolve schemas that depends on other schema.
 func LoadAvroSchema(rawSchema string, registry agentiface.SchemaRegistry) (agentiface.Schema, error) {
 	// retrieve all schemas from the registry that are avro
-	// this is not efficient, but I can't probably can't do more
+	// this is not efficient, but I can't probably do more
 	ids := registry.SchemaListIds()
 	schemas := make(map[string]avro.Schema)
 
@@ -112,72 +110,9 @@ func LoadAvroSchema(rawSchema string, registry agentiface.SchemaRegistry) (agent
 	}
 
 	return &AvroSchema{
-		id:       avroSchema.GetName(),
-		title:    title,
-		mimetype: MimeTypeAvroSchema,
-		raw:      avroSchema.String(),
-		schema:   avroSchema,
+		id:     avroSchema.GetName(),
+		title:  title,
+		raw:    avroSchema.String(),
+		schema: avroSchema,
 	}, nil
-}
-
-// SchemaRegistry represents a registry for schemas.
-type SchemaRegistry struct {
-	schemas map[string]agentiface.Schema
-}
-
-// NewSchemaRegistry creates a new instance of SchemaRegistry.
-// nolint: unparam, parameter a is reserved for a future usage
-func NewSchemaRegistry(a agentiface.Agent) *SchemaRegistry {
-	return &SchemaRegistry{
-		schemas: make(map[string]agentiface.Schema),
-	}
-}
-
-// SchemaRegister registers a schema in the registry.
-func (s *SchemaRegistry) SchemaRegister(schema agentiface.Schema) (string, error) {
-	s.schemas[schema.ID()] = schema
-
-	return schema.ID(), nil
-}
-
-// SchemaGetByID returns a schema which id matches the one in parameter.
-func (s *SchemaRegistry) SchemaGetByID(id string) (agentiface.Schema, error) {
-	schema, ok := s.schemas[id]
-
-	if !ok {
-		return nil, fmt.Errorf("No schema found in the registry with id '%s'", id)
-	}
-
-	return schema, nil
-}
-
-// SchemaListIds returns a map of <id, schema> known by the registry.
-func (s *SchemaRegistry) SchemaListIds() []string {
-	values := make([]string, len(s.schemas))
-
-	i := 0
-	for k := range s.schemas {
-		values[i] = k
-		i++
-	}
-
-	return values
-}
-
-// SchemaUnregister remove a schema from the registry.
-func (s *SchemaRegistry) SchemaUnregister(id string) error {
-	if !s.SchemaExist(id) {
-		return fmt.Errorf("No schema found in the registry with id '%s'", id)
-	}
-
-	delete(s.schemas, id)
-
-	return nil
-}
-
-// SchemaExist returns true if the key match a schema known by the registry.
-func (s *SchemaRegistry) SchemaExist(key string) bool {
-	_, ok := s.schemas[key]
-
-	return ok
 }

--- a/agentimpl/schemaJson.go
+++ b/agentimpl/schemaJson.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2016 Christophe Camel, Jonathan Pigrée
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/crucibuild/sdk-agent-go/agentiface"
+	"github.com/crucibuild/sdk-agent-go/util"
+)
+
+// MimeTypeJSONSchema represents the mime type we use for JSON schemas.
+const MimeTypeJSONSchema = "application/schema+json"
+
+const jsonID = "id"
+const jsonTitle = "title"
+
+// JSONSchema represents a JSON Schema with all its metadata.
+type JSONSchema struct {
+	id    string
+	title string
+	raw   string
+}
+
+// ID returns the JSONSchema ID.
+func (s *JSONSchema) ID() string {
+	return s.id
+}
+
+// Title returns the JSONSchema title.
+func (s *JSONSchema) Title() string {
+	return s.title
+}
+
+// MimeType returns the JSONSchema mime type.
+func (*JSONSchema) MimeType() string {
+	return MimeTypeJSONSchema
+}
+
+// Raw returns the raw JSONSchema.
+func (s *JSONSchema) Raw() string {
+	return s.raw
+}
+
+// Decode unserializes data using the JSONSchema registered.
+func (s *JSONSchema) Decode(o []byte, t agentiface.Type) (interface{}, error) {
+	// Create a new record to decode data into
+	decodedRecord := util.New(t.Type())
+
+	// decode
+	err := json.Unmarshal(o, decodedRecord)
+
+	return decodedRecord, err
+}
+
+// Code serializes data using the JSONSchema registered.
+func (s *JSONSchema) Code(o interface{}) ([]byte, error) {
+	return json.Marshal(o)
+}
+
+// LoadJSONSchema loads the given Json Schema and returns a schema instance
+func LoadJSONSchema(rawSchema string) (agentiface.Schema, error) {
+	// The given json schema is a json, so load it
+	var decoded interface{}
+	err := json.Unmarshal([]byte(rawSchema), &decoded)
+
+	if err != nil {
+		return nil, err
+	}
+
+	schema := decoded.(map[string]interface{})
+
+	id, ok := schema[jsonID]
+
+	if !ok {
+		return nil, fmt.Errorf("id (key: %s) was expected in schema", jsonID)
+	}
+
+	switch id.(type) {
+	case string:
+		// ok
+		break
+	default:
+		return nil, fmt.Errorf("id (key: %s) value must be a JSON string in schema", jsonID)
+	}
+
+	return &JSONSchema{
+		id:    id.(string),
+		title: schema[jsonTitle].(string),
+		raw:   rawSchema,
+	}, nil
+}

--- a/agentimpl/schemaJson_test.go
+++ b/agentimpl/schemaJson_test.go
@@ -1,0 +1,148 @@
+package agentimpl
+
+import (
+	"fmt"
+	"github.com/crucibuild/sdk-agent-go/agentiface"
+	"github.com/crucibuild/sdk-agent-go/util"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+const (
+	schemaID    = "http://github.com/crucibuild/sdk-agent-go/schema/person-test"
+	schemaTitle = "Person"
+)
+
+var personSchema = fmt.Sprintf(`{
+			"id": "%s",
+			"title": "%s",
+			"type": "object",
+			"properties": {
+				"firstName": {
+					"type": "string"
+				},
+				"lastName": {
+					"type": "string"
+				},
+				 "age": {
+            		"description": "Age in years",
+            		"type": "integer",
+            		"minimum": 0
+        		}
+			},
+			"required": ["firstName", "lastName"]
+		}`, schemaID, schemaTitle)
+
+type person struct {
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Age       int    `json:"age"`
+}
+
+var personType agentiface.Type
+
+func TestLoadJsonSchema(t *testing.T) {
+	Convey(fmt.Sprintf("Given a JSon Schema (%s)", schemaTitle), t, func() {
+
+		Convey("When when we call the LoadJSONSchema() function", func() {
+			schema, err := LoadJSONSchema(personSchema)
+
+			Convey("No error should occur", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Schema instance should not be nil", func() {
+				So(schema, ShouldNotBeNil)
+			})
+
+			Convey(fmt.Sprintf("Schema id should equal %s", schemaID), func() {
+				So(schema.ID(), ShouldEqual, schemaID)
+			})
+
+			Convey(fmt.Sprintf("Schema title should equal %s", schemaID), func() {
+				So(schema.Title(), ShouldEqual, schemaTitle)
+			})
+
+			Convey(fmt.Sprintf("Schema mimetype should equal %s", MimeTypeJSONSchema), func() {
+				So(schema.Title(), ShouldEqual, schemaTitle)
+			})
+		})
+	})
+}
+
+func TestJSONDecode(t *testing.T) {
+	Convey(fmt.Sprintf(`Given:
+- a schema instance (mimetype %s)
+- a type (%s)
+- an array of bytes representing a json instance of the schema`, MimeTypeJSONSchema, personType.Name()), t, func() {
+		schema, err := LoadJSONSchema(personSchema)
+		payload := []byte(`{"firstName": "john", "lastName": "doe", "age": 74}`)
+
+		Convey("No error should occur when loading schema", func() {
+			So(err, ShouldBeNil)
+		})
+
+		Convey("When when we decode the bytes", func() {
+			decoded, err := schema.Decode(payload, personType)
+
+			Convey("No error should occur", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Decoded instance should not be nil", func() {
+				So(decoded, ShouldNotBeNil)
+			})
+
+			Convey(fmt.Sprintf("Decoded instance should have the type '%s'", personType.Name()), func() {
+				So(decoded, ShouldHaveSameTypeAs, &person{})
+			})
+
+			Convey("Decoded instance should have expected values", func() {
+				p := decoded.(*person)
+
+				So(p.FirstName, ShouldEqual, "john")
+				So(p.LastName, ShouldEqual, "doe")
+				So(p.Age, ShouldEqual, 74)
+			})
+		})
+	})
+}
+
+func TestJSONEncode(t *testing.T) {
+	Convey(fmt.Sprintf(`Given:
+- a schema instance (mimetype %s)
+- a type (%s)
+- an instance of that type`, MimeTypeJSONSchema, personType.Name()), t, func() {
+		schema, err := LoadJSONSchema(personSchema)
+		p := &person{FirstName: "john", LastName: "doe", Age: 74}
+
+		Convey("No error should occur when loading schema", func() {
+			So(err, ShouldBeNil)
+		})
+
+		Convey("When when we encode the instance", func() {
+			coded, err := schema.Code(p)
+
+			Convey("No error should occur", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Coded bytes should not be nil", func() {
+				So(coded, ShouldNotBeNil)
+			})
+
+			Convey("Coded bytes should have expected value", func() {
+				fmt.Print("-->", string(coded))
+				So(string(coded), ShouldEqual, `{"firstName":"john","lastName":"doe","age":74}`)
+			})
+		})
+	})
+}
+
+func init() {
+	t, err := util.GetStructType(&person{})
+	if err != nil {
+		panic(err)
+	}
+	personType = NewTypeFromType("person", t)
+}

--- a/agentimpl/schemaRegistry.go
+++ b/agentimpl/schemaRegistry.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2016 Christophe Camel, Jonathan Pigrée
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentimpl
+
+import (
+	"fmt"
+	"github.com/crucibuild/sdk-agent-go/agentiface"
+)
+
+// SchemaRegistry represents a registry for schemas.
+type SchemaRegistry struct {
+	schemas map[string]agentiface.Schema
+}
+
+// NewSchemaRegistry creates a new instance of SchemaRegistry.
+// nolint: unparam, parameter a is reserved for a future usage
+func NewSchemaRegistry(a agentiface.Agent) *SchemaRegistry {
+	return &SchemaRegistry{
+		schemas: make(map[string]agentiface.Schema),
+	}
+}
+
+// SchemaRegister registers a schema in the registry.
+func (s *SchemaRegistry) SchemaRegister(schema agentiface.Schema) (string, error) {
+	s.schemas[schema.ID()] = schema
+
+	return schema.ID(), nil
+}
+
+// SchemaGetByID returns a schema which id matches the one in parameter.
+func (s *SchemaRegistry) SchemaGetByID(id string) (agentiface.Schema, error) {
+	schema, ok := s.schemas[id]
+
+	if !ok {
+		return nil, fmt.Errorf("No schema found in the registry with id '%s'", id)
+	}
+
+	return schema, nil
+}
+
+// SchemaListIds returns a map of <id, schema> known by the registry.
+func (s *SchemaRegistry) SchemaListIds() []string {
+	values := make([]string, len(s.schemas))
+
+	i := 0
+	for k := range s.schemas {
+		values[i] = k
+		i++
+	}
+
+	return values
+}
+
+// SchemaUnregister remove a schema from the registry.
+func (s *SchemaRegistry) SchemaUnregister(id string) error {
+	if !s.SchemaExist(id) {
+		return fmt.Errorf("No schema found in the registry with id '%s'", id)
+	}
+
+	delete(s.schemas, id)
+
+	return nil
+}
+
+// SchemaExist returns true if the key match a schema known by the registry.
+func (s *SchemaRegistry) SchemaExist(key string) bool {
+	_, ok := s.schemas[key]
+
+	return ok
+}


### PR DESCRIPTION
Here is the implementation for the enhancement #22.

I have the feeling that it would be very valuable to have the support for the JSON schema.

As one can see, the implementation is realy simple as the encoding/decoding of json is natively supported by go and there is no need for special tricks (reflection, dependency link) as we had for Avro.

I took the opportunity to break out the files by concern, as @jpigree had already suggested. This is much better and more maintainable.

At last, the best part of this PR is the unit tests that cover the nominal cases of using json schema: loading, coding, decoding. It can be used as a good basis for writing tests for avro schema.